### PR TITLE
Support for MaxOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,22 @@
+ifdef env
+	ifeq ($(env), mac)
+		LIBS := -lncurses
+	else
+		LIBS := -lncursesw
+	endif
+else
+	LIBS := -lncursesw
+endif
+
 CC := gcc
-LIBS := -lncursesw
+SHELL := /bin/bash
 OBJS := typing.o main.o logging.o display.o
 PROGRAM := typing
 
 ${PROGRAM}: ${OBJS}
+#	#${SHELL} -c 'if [ "$$(uname)" == "Darwin" ] ; then LIBS=-lncurses ; fi'
+#	${SHELL} -c 'if [ "$$(uname)" == "Linux" ] ; then LIBS="-lncurses" ; fi'
+#	${SHELL} -c 'echo ${LIBS}'
 	${CC} -o ${PROGRAM} typing.o main.o logging.o display.o ${LIBS}
 typing.o: typing.h display.h typing.c
 	${CC} -c typing.c ${LIBS}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Retro typing game written in C.
 * **NOTE**: Only tested following environments:
     1. Ubuntu 16.04.3 LTS
     1. CentOS Linux release 7.4.1708 (Core)
+    1. MaxOS X Yosemite 10.10.5
 
 ## For Ubuntu
 
@@ -31,6 +32,7 @@ Please install following packages:
 sudo yum install -y gcc make ncurses-devel
 ```
 
+
 # How to Play
 
 1. Open terminal app.
@@ -44,11 +46,18 @@ sudo yum install -y gcc make ncurses-devel
    git clone https://github.com/fkawa-play/retro-typing.git
    ```
 1. Compile and generate a binary:
+    * Ubuntu / CentOS
 
-   ```
-   pushd retro-typing/
-   make
-   ```
+       ```
+       pushd retro-typing/
+       make
+       ```
+    * MacOS
+
+       ```
+       pushd retro-typing/
+       make env=mac
+       ```
 1. Run the binary.  Let's play!!!:
 
    ```

--- a/typing.c
+++ b/typing.c
@@ -236,8 +236,8 @@ void load_questions(Question *q) {
     FILE *fp_ruby;
     FILE *fp_jp;
 
-    char *filename_ruby = (char *)malloc(sizeof(FILENAME));
-    char *filename_jp = (char *)malloc(sizeof(FILENAME));
+    char *filename_ruby = (char *)malloc(sizeof(char) * FILENAME);
+    char *filename_jp = (char *)malloc(sizeof(char) * FILENAME);
 
     if(filename_ruby == NULL || filename_jp == NULL) {
         logger(ERROR, "Cannot allocate memory");
@@ -356,8 +356,8 @@ void typing(Typing *T, Question *Q) {
     int total_len_chars = 0;
 
     // Initialize
-    combo_msg = (char *)malloc(MAX_COMBO_MSG * sizeof(char));
-    dup = (short *)malloc(MAX_QUESTIONS * sizeof(short));
+    combo_msg = (char *)malloc(sizeof(char) * MAX_COMBO_MSG);
+    dup = (short *)malloc(sizeof(short) * MAX_QUESTIONS);
     if (combo_msg == NULL || dup == NULL) {
         logger(CRITICAL, "Cannot allocate memory.. exit.");
         reset_and_exit(EXIT_FAILURE);


### PR DESCRIPTION
This commit supports for MaxOS.  To play on MaxOS, run 'make env=mac' and
'./typing'.  NOTE: Only tested in MacOS X 10.10.5.  In addition, this commit
also fixes wrong allocation for malloc.