### PR TITLE
Prepare unittest.

### DIFF
--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -46,7 +46,7 @@ rm ranking/*.log
 # How to test
 
 This project has unit tests using googletest testing framework.
-You can build and execute unit tests as follows.
+You can build and execute unit tests as follows. **Note that currently not to support MacOS**.
 
 **Requirements**: cmake version 3.1 or later.
 

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -57,10 +57,8 @@ sudo apt install cmake
 ```
 
 ```
-cd unittests/
-mkdir build
-cd build
-cmake ..
+cd unittests
+cmake .
 make
 ./unittests
 ```

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -48,9 +48,19 @@ rm ranking/*.log
 This project has unit tests using googletest testing framework.
 You can build and execute unit tests as follows.
 
+**Requirements**: cmake version 3.1 or later.
+
+Install cmake before you build unit tests.
+
+```
+sudo apt install cmake
+```
+
 ```
 cd unittests/
-cmake .
+mkdir build
+cd build
+cmake ..
 make
 ./unittests
 ```

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -43,6 +43,18 @@ rm ranking/*.log
    (Then, press `Shift + f`)
    ```
 
+# How to test
+
+This project has unit tests using googletest testing framework.
+You can build and execute unit tests as follows.
+
+```
+cd unittests/
+cmake .
+make
+./unittests
+```
+
 # Motivation/MEMO
 
 * When I was 18 years old, I wanted to create a typing game which is enable to

--- a/unittests/.gitignore
+++ b/unittests/.gitignore
@@ -1,0 +1,16 @@
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+gmock.pc
+gmock_main.pc
+googletest-download/
+googletest-src/
+gtest.pc
+gtest_main.pc
+unittests

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,3 +1,13 @@
+cmake_minimum_required(VERSION 3.1)
+project(retro-typing)
+enable_language(CXX)
+set(CMAKE_CXX_STANDARD 11) # C++11
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+
+if(COMMAND cmake_policy)
+  cmake_policy(SET CMP0003 NEW)
+endif(COMMAND cmake_policy)
+
 # Download and unpack googletest at configure time
 configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
@@ -34,9 +44,6 @@ endif()
 find_package(PkgConfig)
 pkg_check_modules(NCURSESW REQUIRED ncursesw)
 include_directories(${NCURSESW_INCLUDE_DIRS} ../)
-
-# Unit tests use c++11
-add_definitions("-Wall -std=c++11")
 
 # Now simply link against gtest or gtest_main as needed. Eg
 add_executable(unittests ../typing.c ../logging.c ../display.c typing_test.cpp)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Download and unpack googletest at configure time
+configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                 ${CMAKE_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
+
+# The gtest/gtest_main targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if (CMAKE_VERSION VERSION_LESS 2.8.11)
+  include_directories("${gtest_SOURCE_DIR}/include")
+endif()
+
+# Add ncursesw
+find_package(PkgConfig)
+pkg_check_modules(NCURSESW REQUIRED ncursesw)
+include_directories(${NCURSESW_INCLUDE_DIRS} ../)
+
+# Unit tests use c++11
+add_definitions("-Wall -std=c++11")
+
+# Now simply link against gtest or gtest_main as needed. Eg
+add_executable(unittests ../typing.c ../logging.c ../display.c typing_test.cpp)
+target_link_libraries(unittests gtest_main ${NCURSESW_LIBRARIES})

--- a/unittests/CMakeLists.txt.in
+++ b/unittests/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+CMAKE_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/unittests/typing_test.cpp
+++ b/unittests/typing_test.cpp
@@ -1,0 +1,64 @@
+/******************************************************************************
+MIT License
+
+Copyright (c) 2018 tomoyuki-nakabayashi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#include <gtest/gtest.h>
+extern "C" {
+#include <typing.h>
+}
+int flag_completed = FALSE; // instead of product code of main.c
+
+namespace typing_test {
+class TypingTest : public ::testing::Test {
+ protected:
+    virtual void SetUp()
+    {
+    }
+
+    virtual void TearDown()
+    {
+    }
+};
+
+TEST_F(TypingTest, ExitFromRetroTyping) {
+  EXPECT_DEATH(reset_and_exit(1), "");
+}
+
+TEST_F(TypingTest, CToI) {
+  EXPECT_EQ(0, ctoi('0'));
+  EXPECT_EQ(1, ctoi('1'));
+  EXPECT_EQ(9, ctoi('9'));
+
+  EXPECT_EQ(0, ctoi('A'));
+  EXPECT_EQ(0, ctoi(-1));
+}
+
+TEST_F(TypingTest, GetComboMsgYeah) {
+  constexpr int kMoreThanTen = 20;
+  std::unique_ptr<char> actual {new char[MAX_SENTENSES]};
+  get_combo_msg(actual.get(), kMoreThanTen);
+
+  EXPECT_STREQ("Yeah!!", actual.get());
+}
+
+}  // namespace typing_test


### PR DESCRIPTION
### Overview
This relates with #3.
I prepared an unit test environment using googletest.

You can build and execute tests as follows:
```
cd unittests
cmake .
make
./unittests
```

### Changed contents
I set up CMake build scripts and made the first few tests.

### Impact of this change
The change never affects product code.

### Requirements for this change
Note that, I just built and executed the test only on Linux (Ubuntu 16.04).
I'm not sure the build script can work on other environment (e.g., Mac).
To build tests, CMake is additionally required (My CMake version is 3.5.1) .

### Supplement
<!-- If you have some point of views for reviewing or NOTE, please describe -->
